### PR TITLE
adds work for the pang10 keyboard

### DIFF
--- a/system76_backlight_manager/keyboard_backlight.py
+++ b/system76_backlight_manager/keyboard_backlight.py
@@ -16,6 +16,7 @@ class KeyboardBacklight:
         "darp6": SINGLE_BACKLIGHT_PATH,
         "oryp6": SINGLE_BACKLIGHT_PATH,
         "oryp4": FOUR_BACKLIGHT_PATH,
+        "pang10": SINGLE_BACKLIGHT_PATH,
         "serw11": FOUR_BACKLIGHT_PATH,
         "serw12": FOUR_BACKLIGHT_PATH,
         # More to come

--- a/system76_backlight_manager/keyboard_backlight.py
+++ b/system76_backlight_manager/keyboard_backlight.py
@@ -16,7 +16,7 @@ class KeyboardBacklight:
         "darp6": SINGLE_BACKLIGHT_PATH,
         "oryp6": SINGLE_BACKLIGHT_PATH,
         "oryp4": FOUR_BACKLIGHT_PATH,
-        "pang10": SINGLE_BACKLIGHT_PATH,
+        "pang10": LEGACY_SINGLE_BACKLIGHT_PATH,
         "serw11": FOUR_BACKLIGHT_PATH,
         "serw12": FOUR_BACKLIGHT_PATH,
         # More to come


### PR DESCRIPTION
Here are the file paths for this model:

[pang10-tree-sys-class-leds-system76-kbd-backlight.txt](https://github.com/JeffLabonte/System76-Backlight-Manager-cli/files/6151879/pang10-tree-sys-class-leds-system76-kbd-backlight.txt)

It works like the Darter Pro which is a Single Zone keyboard so it should work just fine. 