### PR TITLE
Added Oryx Pro 5

### DIFF
--- a/system76_backlight_manager/keyboard_backlight.py
+++ b/system76_backlight_manager/keyboard_backlight.py
@@ -16,6 +16,7 @@ class KeyboardBacklight:
         "darp5": LEGACY_SINGLE_BACKLIGHT_PATH,
         "darp6": SINGLE_BACKLIGHT_PATH,
         "oryp4": FOUR_BACKLIGHT_PATH,
+        "oryp5": FOUR_BACKLIGHT_PATH,
         "oryp6": SINGLE_BACKLIGHT_PATH,
         "oryp4": FOUR_BACKLIGHT_PATH,
         "serw11": FOUR_BACKLIGHT_PATH,


### PR DESCRIPTION
Simply added  Oryx Pro 5 to the list of models mappings. Worked on my personal Oryx Pro 5.